### PR TITLE
Configurable aarch64 machine

### DIFF
--- a/hw/avatar/Makefile.objs
+++ b/hw/avatar/Makefile.objs
@@ -1,4 +1,5 @@
 obj-$(TARGET_ARM)  += avatar_posix.o configurable_machine.o remote_memory.o arm_helper.o
+obj-$(TARGET_AARCH64)  += avatar_posix.o configurable_machine.o remote_memory.o arm_helper.o
 obj-$(TARGET_MIPS) += avatar_posix.o configurable_machine.o remote_memory.o mips_helper.o
 obj-$(TARGET_PPC) += configurable_machine.o
 obj-$(TARGET_I386) += configurable_machine.o

--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -482,7 +482,12 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
 #if defined(TARGET_ARM)
     ObjectClass *cpu_oc;
     Object *cpuobj;
+
+#ifdef TARGET_AARCH64
+    if (!cpu_model) cpu_model = "cortex-a57";
+#else
     if (!cpu_model) cpu_model = "arm926";
+#endif
 
     qemu_log_mask(LOG_AVATAR, "Configurable: Adding processor %s\n", cpu_model);
 
@@ -544,8 +549,14 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
     }
 
 #if defined(TARGET_ARM)
+#ifdef TARGET_AARCH64
+    set_feature(&cpuu->env, ARM_FEATURE_AARCH64);
+    set_feature(&cpuu->env, ARM_FEATURE_CONFIGURABLE);
+#else
     avatar_add_banked_registers(cpuu);
     set_feature(&cpuu->env, ARM_FEATURE_CONFIGURABLE);
+#endif
+
 #elif defined(TARGET_I386)
     // Ensures CS register is set correctly on x86/x86_64 CPU reset. See target/i386/cpu.c:3063
     int mode =

--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -192,6 +192,10 @@ class PandaArch():
 
         base_reg_s = "SP"
         base_reg_val = self.get_reg(cpu, self.reg_sp)
+        if base_reg_val == 0:
+            print("[WARNING: no stack pointer]")
+            return
+        
         word_size = int(self.panda.bits/4)
 
         for word_idx in range(words):
@@ -308,6 +312,9 @@ class Aarch64Arch(PandaArch):
         '''
         Return an aarch64 register
         '''
+        if reg == 32:
+            print("WARNING: unsupported get sp for aarch64")
+            return 0
         return cpu.env_ptr.xregs[reg]
 
     def _set_reg_val(self, cpu, reg, val):


### PR DESCRIPTION
Partly from upstream Panda: https://github.com/panda-re/panda/pull/984/files

This merge is needed  for https://github.com/FirmWire/FirmWire/issues/8 

Note that this is only for the Armv8
The Cortex A55 and A76 needed for the Shannon are not yet supported in this merge. ( Armv8.2 is needed, since RAS feature set is used for the given firmware. (Ghidra function at 0x0000b82c, called in reset 0x000000c8)