### PR TITLE
Add Cortex A55 and Cortex A76 definition

### DIFF
--- a/target/arm/cpu64.c
+++ b/target/arm/cpu64.c
@@ -212,6 +212,147 @@ static void aarch64_a53_initfn(Object *obj)
     define_arm_cp_regs(cpu, cortex_a57_a53_cp_reginfo);
 }
 
+static void aarch64_a76_initfn(Object *obj)
+{
+    ARMCPU *cpu = ARM_CPU(obj);
+
+    cpu->dtb_compatible = "arm,cortex-a76";
+    set_feature(&cpu->env, ARM_FEATURE_V8);
+    set_feature(&cpu->env, ARM_FEATURE_NEON);
+    set_feature(&cpu->env, ARM_FEATURE_GENERIC_TIMER);
+    set_feature(&cpu->env, ARM_FEATURE_AARCH64);
+    set_feature(&cpu->env, ARM_FEATURE_CBAR_RO);
+    set_feature(&cpu->env, ARM_FEATURE_EL2);
+    set_feature(&cpu->env, ARM_FEATURE_EL3);
+    set_feature(&cpu->env, ARM_FEATURE_PMU);
+
+    /* Ordered by B2.4 AArch64 registers by functional group */
+    cpu->clidr = 0x82000023;
+    cpu->ctr = 0x8444C004;
+    cpu->dcz_blocksize = 4;
+    cpu->id_aa64dfr0  = 0x0000000010305408ull;
+    cpu->id_aa64isar0 = 0x0000100010211120ull;
+    cpu->id_aa64isar1 = 0x0000000000100001ull;
+    cpu->id_aa64mmfr0 = 0x0000000000101122ull;
+    cpu->id_aa64mmfr1 = 0x0000000010212122ull;
+    // cpu->id_aa64mmfr2 = 0x0000000000001011ull;
+    cpu->id_aa64pfr0  = 0x1100000010111112ull; /* GIC filled in later */
+    cpu->id_aa64pfr1  = 0x0000000000000010ull;
+    cpu->id_afr0       = 0x00000000;
+    cpu->id_dfr0  = 0x04010088;
+    cpu->id_isar0 = 0x02101110;
+    cpu->id_isar1 = 0x13112111;
+    cpu->id_isar2 = 0x21232042;
+    cpu->id_isar3 = 0x01112131;
+    cpu->id_isar4 = 0x00010142;
+    cpu->id_isar5 = 0x01011121;
+    // cpu->id_isar6 = 0x00000010;
+    cpu->id_mmfr0 = 0x10201105;
+    cpu->id_mmfr1 = 0x40000000;
+    cpu->id_mmfr2 = 0x01260000;
+    cpu->id_mmfr3 = 0x02122211;
+    cpu->id_mmfr4 = 0x00021110;
+    cpu->id_pfr0  = 0x10010131;
+    cpu->id_pfr1  = 0x00010000; /* GIC filled in later */
+    // cpu->id_pfr2  = 0x00000011;
+    cpu->midr = 0x414fd0b1;          /* r4p1 */
+    cpu->revidr = 0;
+
+    /* From B2.18 CCSIDR_EL1 */
+    cpu->ccsidr[0] = 0x701fe01a; /* 64KB L1 dcache */
+    cpu->ccsidr[1] = 0x201fe01a; /* 64KB L1 icache */
+    cpu->ccsidr[2] = 0x707fe03a; /* 512KB L2 cache */
+
+    /* From B2.93 SCTLR_EL3 */
+    cpu->reset_sctlr = 0x30c50838;
+
+    /* From B4.23 ICH_VTR_EL2 */
+    cpu->gic_num_lrs = 4;
+    cpu->gic_vpribits = 5;
+    cpu->gic_vprebits = 5;
+
+    /* From B5.1 AdvSIMD AArch64 register summary */
+    cpu->mvfr0 = 0x10110222;
+    cpu->mvfr1 = 0x13211111;
+    cpu->mvfr2 = 0x00000043;
+
+    // ARM cortex-a55 core technical manual; DBGDIDR, Debug ID Register.
+    cpu->dbgdidr = 0x35185000;
+}
+
+static void aarch64_a55_initfn(Object *obj)
+{
+
+    ARMCPU *cpu = ARM_CPU(obj);
+
+    cpu->dtb_compatible = "arm,cortex-a55";
+    set_feature(&cpu->env, ARM_FEATURE_V8);
+    set_feature(&cpu->env, ARM_FEATURE_NEON);
+    set_feature(&cpu->env, ARM_FEATURE_GENERIC_TIMER);
+    set_feature(&cpu->env, ARM_FEATURE_AARCH64);
+    set_feature(&cpu->env, ARM_FEATURE_CBAR_RO);
+    set_feature(&cpu->env, ARM_FEATURE_EL2);
+    set_feature(&cpu->env, ARM_FEATURE_EL3);
+    set_feature(&cpu->env, ARM_FEATURE_PMU);
+
+    /* Ordered by B2.4 AArch64 registers by functional group */
+    cpu->clidr = 0x82000023;
+    cpu->ctr = 0x84448004; /* L1Ip = VIPT */
+    cpu->dcz_blocksize = 4; /* 64 bytes */
+    cpu->id_aa64dfr0  = 0x0000000010305408ull;
+    cpu->id_aa64isar0 = 0x0000100010211120ull;
+    cpu->id_aa64isar1 = 0x0000000000100001ull;
+    cpu->id_aa64mmfr0 = 0x0000000000101122ull;
+    cpu->id_aa64mmfr1 = 0x0000000010212122ull;
+    // cpu->id_aa64mmfr2 = 0x0000000000001011ull;
+    cpu->id_aa64pfr0  = 0x0000000010112222ull;
+    cpu->id_aa64pfr1  = 0x0000000000000010ull;
+    cpu->id_afr0       = 0x00000000;
+    cpu->id_dfr0  = 0x04010088;
+    cpu->id_isar0 = 0x02101110;
+    cpu->id_isar1 = 0x13112111;
+    cpu->id_isar2 = 0x21232042;
+    cpu->id_isar3 = 0x01112131;
+    cpu->id_isar4 = 0x00011142;
+    cpu->id_isar5 = 0x01011121;
+    // cpu->id_isar6 = 0x00000010;
+    cpu->id_mmfr0 = 0x10201105;
+    cpu->id_mmfr1 = 0x40000000;
+    cpu->id_mmfr2 = 0x01260000;
+    cpu->id_mmfr3 = 0x02122211;
+    cpu->id_mmfr4 = 0x00021110;
+    cpu->id_pfr0  = 0x10010131;
+    cpu->id_pfr1  = 0x00011011;
+    // cpu->id_pfr2  = 0x00000011;
+    cpu->midr = 0x412FD050;          /* r2p0 */
+    cpu->revidr = 0;
+
+    /* From B2.23 CCSIDR_EL1 */
+    cpu->ccsidr[0] = 0x700fe01a; /* 32KB L1 dcache */
+    cpu->ccsidr[1] = 0x200fe01a; /* 32KB L1 icache */
+    cpu->ccsidr[2] = 0x703fe07a; /* 512KB L2 cache */
+
+    /* From B2.96 SCTLR_EL3 */
+    cpu->reset_sctlr = 0x30c50838;
+
+    /* From B4.45 ICH_VTR_EL2 */
+    cpu->gic_num_lrs = 4;
+    cpu->gic_vpribits = 5;
+    cpu->gic_vprebits = 5;
+    // cpu->gic_pribits = 5;
+
+    cpu->mvfr0 = 0x10110222;
+    cpu->mvfr1 = 0x13211111;
+    cpu->mvfr2 = 0x00000043;
+
+    /* From D5.4 AArch64 PMU register summary */
+    // cpu->reset_pmcr_el0 = 0x410b3000;
+
+    // ARM cortex-a55 core technical manual; DBGDIDR, Debug ID Register.
+    cpu->dbgdidr = 0x35185000;
+}
+
+
 #ifdef CONFIG_USER_ONLY
 static void aarch64_any_initfn(Object *obj)
 {
@@ -240,6 +381,9 @@ typedef struct ARMCPUInfo {
 static const ARMCPUInfo aarch64_cpus[] = {
     { .name = "cortex-a57",         .initfn = aarch64_a57_initfn },
     { .name = "cortex-a53",         .initfn = aarch64_a53_initfn },
+    { .name = "cortex-a76",         .initfn = aarch64_a76_initfn },
+    { .name = "cortex-a55",         .initfn = aarch64_a55_initfn },
+
 #ifdef CONFIG_USER_ONLY
     { .name = "any",         .initfn = aarch64_any_initfn },
 #endif


### PR DESCRIPTION
Mostly picked from upstream QEMU. Some variables are commented out, as not all ARMv8.x features such as PAN are  supported in the PANDA version, thus these variables are not used in ARMCPU.

Example test code:
```
from avatar2 import *
from pandare import Panda

import logging as log
import capstone

class ARM_CORTEX_A55(ARM):
    cpu_model = "cortex-a55"
    qemu_name = "aarch64"
    gdb_name = "aarch64"
    angr_name = "aarch64"
    capstone_arch = CS_ARCH_ARM64
    capstone_mode = CS_MODE_LITTLE_ENDIAN
    keystone_arch = KS_ARCH_ARM64
    keystone_mode = KS_MODE_LITTLE_ENDIAN | KS_MODE_THUMB
    unicorn_arch = UC_ARCH_ARM64
    unicorn_mode = UC_MODE_LITTLE_ENDIAN | UC_MODE_THUMB

    @staticmethod
    def init(avatar):
        pass


avatar = Avatar(
        arch=ARM_CORTEX_A55,
)
avatar.load_plugin("disassembler")
avatar.load_plugin("assembler")

entry_address = 0
assembly_code = b"\x20\x00\x80\xd2\x01\x08\x80\xd2"

qemu = avatar.add_target(
            PyPandaTarget,
            name="Custom_emulator",
            gdb_executable="gdb-multiarch",
            gdb_port=3333,
            qmp_port=3334,
            entry_address=entry_address,
            log_file="/dev/stdout",

        )
def fake_signal_handler(*args, **kwargs):
    pass
Panda.setup_internal_signal_handler = fake_signal_handler
Panda._setup_internal_signal_handler = fake_signal_handler

avatar.log.setLevel(log.INFO)

avatar.add_memory_range(
    0,
    size=0x10000,
    name="EXAMPLE_MEMORY",
    permissions="rwx"
)
avatar.init_targets()
qemu.write_memory(qemu.read_register("pc"), len(assembly_code), assembly_code, raw=True )

x0 = qemu.read_register("x0")
print(f"{x0=}")
qemu.step()
x0 = qemu.read_register("x0")
print(f"{x0=}")

x1 = qemu.read_register("x1")
print(f"{x1=}")
qemu.step()
x1 = qemu.read_register("x1")
print(f"{x1=}")

qemu.shutdown()
avatar.shutdown()
```
